### PR TITLE
Sensor dout pin and fetch fixes (#7)

### DIFF
--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -97,6 +97,7 @@ static int hx711_cycle(struct hx711_data *data)
 static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	int ret = 0;
+	int interrupt_cfg_ret;
 	uint32_t count = 0;
 	int i;
 
@@ -138,9 +139,10 @@ static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan
 	data->reading = count;
 
 exit:
-	ret = gpio_pin_interrupt_configure(data->dout_gpio, cfg->dout_pin, GPIO_INT_EDGE_TO_INACTIVE);
-	if (ret != 0) {
+	interrupt_cfg_ret = gpio_pin_interrupt_configure(data->dout_gpio, cfg->dout_pin, GPIO_INT_EDGE_TO_INACTIVE);
+	if (interrupt_cfg_ret != 0) {
 		LOG_ERR("Failed to set dout GPIO interrupt");
+		ret = interrupt_cfg_ret;
 	}
 
 	return ret;
@@ -399,7 +401,7 @@ static int hx711_init(const struct device *dev)
 	k_sem_init(&data->dout_sem, 1, 1);
 
 	/* Configure DOUT as input */
-	data->dout_gpio = cfg->sck_ctrl;
+	data->dout_gpio = cfg->dout_ctrl;
 	LOG_DBG("DOUT pin controller is %p, name is %s\n", data->dout_gpio, data->dout_gpio->name);
 	ret = gpio_pin_configure(data->dout_gpio, cfg->dout_pin, GPIO_INPUT | cfg->dout_flags);
 	if (ret != 0) {


### PR DESCRIPTION
* Use dout ctrl for dout gpio instead of clk

This commit fixes a misusage of the clk ctrl device struct instead of the dout ctrl for the dout gpio



* Retain error return value in hx711_sample_fetch

Before this commit, if any error has happend in the function hx711_sample_fetch before the exit label, the return error would be replaced with the return value from the function
gpio_pin_interrupt_configure. This causes returning success value instead of the error that happend which is misleading.

This commit adds another return error var for the interrupt configure function so we can still retain the previous return value.



---------